### PR TITLE
Rxv modification and Rxz addition

### DIFF
--- a/vyattaconfparser/parser.py
+++ b/vyattaconfparser/parser.py
@@ -13,9 +13,9 @@ else:
 
 rxh = re.compile(r'^([\w\-]+) \{$', re.UNICODE)
 rxl = re.compile(r'^([\w\-]+) ([\w\-\"\./@]+) \{$', re.UNICODE)
-rxv = re.compile(r'^([\w\-]+) "?([^"]+)"?$', re.UNICODE)
+rxv = re.compile(r'^([\w\-]+) "?([^"]+)?"?$', re.UNICODE)
 rxu = re.compile(r'^([\w\-]+)$', re.UNICODE)
-
+rxz = re.compile(r'^(\/\*).*(\*\/)', re.UNICODE)
 
 class ParserException(Exception):
     pass
@@ -71,6 +71,9 @@ def parse_node(config, line, headers=None):
     elif rxu.match(line):
         kv = rxu.match(line).group()
         update_tree(config, headers, {kv: kv})
+
+    elif rxz.match(line):
+        pass
 
     elif line == '}' and headers:
         hq = [list(h.values())[0] for h in headers]


### PR DESCRIPTION
Fixed rxv regex to allow successful parsing of 'password ""' and similar lines, such as from blocks like this:
repository squeeze-lts {
            components "main contrib non-free"
            distribution squeeze-lts
            password ""
            url http://mirrors.kernel.org/debian
            username ""
        }
This avoids errors such as:

> > > out = vyattaconfparser.parse_conf(data)
> > > Traceback (most recent call last):
> > >   File "<stdin>", line 1, in <module>
> > >   File "/usr/local/lib/python2.6/dist-packages/vyattaconfparser/parser.py", line 93, in parse_conf
> > >     c, headers = parse_node(c, line, headers)
> > >   File "/usr/local/lib/python2.6/dist-packages/vyattaconfparser/parser.py", line 82, in parse_node
> > >     raise ParserException('Parse error: "%s"' % line)
> > > vyattaconfparser.parser.ParserException: Parse error: "password """

Added rxz regex check to match comment lines found if directly reading /config/config.boot, like these:
/\* Warning: Do not remove the following line. _/
/_ === vyatta-config-version: "cluster@1:config-management@1:conntrack-sync@1:conntrack@1:cron@1:dhcp-relay@1:dhcp-server@4:firewall@5:ipsec@4:nat@4:qos@1:quagga@2:system@6:vrrp@1:wanloadbalance@3:webgui@1:webproxy@1:zone-policy@1" === _/
/_ Release version: VyOS 1.1.5 */
which are found in /config/config.boot. This avoids a similar ParserException error as above.

Thank you so much for this parser, you saved me hours of work. I hope you don't mind the contribution.
