### PR TITLE
Allow tests to pass in python 3.

### DIFF
--- a/vyattaconfparser/parser.py
+++ b/vyattaconfparser/parser.py
@@ -25,8 +25,8 @@ class ParserException(Exception):
 def update_tree(config, path, val):
     t = config
     for n, i in enumerate(path):
-        if i.keys()[0] not in t:
-            t[i.keys()[0]] = {}
+        if list(i.keys())[0] not in t:
+            t[list(i.keys())[0]] = {}
         t = t[list(i.keys())[0]]
     if isinstance(t, dict):
         if isinstance(val, dict):


### PR DESCRIPTION
Simple change to the code to allow it to work in python v3.5.

It seems that dict().keys() now returns a dict_keys object. http://stackoverflow.com/a/17322707

Python 2 continues to work.
